### PR TITLE
Update datatype-inifile.md

### DIFF
--- a/reference/data-types/datatype-inifile.md
+++ b/reference/data-types/datatype-inifile.md
@@ -27,7 +27,7 @@ This is the type for the ini file that was referenced from `${Ini}`
 
     === "Lua"
 
-        Remove the buff named "Crerdence"
+        Does the file "sample.ini" exist?
 
         ```lua
         mq.TLO.Ini.File("sample").Exists()


### PR DESCRIPTION
Minor documentation update.

'Remove the buff named "Crerdence"' ---  in the LUA Example looks like a copy/paste issue from other examples.