### PR TITLE
Fixes #35

### DIFF
--- a/reference/top-level-objects/tlo-finditembank.md
+++ b/reference/top-level-objects/tlo-finditembank.md
@@ -4,23 +4,52 @@ tags:
 ---
 # `FindItemBank`
 
-Find item in bank by partial name match. Using =name will find an exact match only.
+A TLO used to find an item in your bank by partial or exact name match. _See examples below._
 
 Of note: The FindItemBank with ItemSlot REQUIRES that bank item containers be open to function correctly. Due to potential exploits the command will not work if the bank containers are closed. This is in contrast to FindItem functionality with character containers, where ItemSlot was designed to allow inventory management without opening containers.
 
 ## Forms
 
-|  |  |
-| :--- | :--- |
-| [_item_](../data-types/datatype-item.md) **FindItemBank[**name**]** | Returns item in your bank by partial name match |
-| [_item_](../data-types/datatype-item.md) **FindItemBank[**=name**]** | Returns item in your bank by exact name match |
+[_item_][item] **FindItemBank**[_name/id_]
 
-## Examples
+:   Search for an item in your bank using the given item id, or partial name match.
 
-`/echo ${FindItemBank[=Swirling Shadows]}`
+    ??? example
 
-This is a simple example with little use, but If the item is found, the name of the item will be echoed
+        Looks for an item in your bank with the name swirling in it, and prints the ID.
 
-`/echo ${FindItemBank[=Swirling Shadows].ItemSlot}`
+        === "MQScript"
 
-Will return Bank's item slot
+            ```
+            /echo ${FindItemBank[swirling].ID}
+            ```
+
+        === "Lua"
+
+            ```lua
+            print(mq.TLO.FindItemBank("swirling").ID())
+            ```
+
+
+[_item_][item] **FindItemBank**[=_name_]
+
+:   Search for an item in your bank using exact name match (case insensntive).
+
+    ??? example
+
+        Looks for the Cleric Epic (by exact match) in your bank and prints its ID.
+
+        === "MQScript"
+
+            ```
+            /echo ${FindItemBank[=Water Sprinkler of Nem Ankh].ID}
+            ```
+
+        === "Lua"
+
+            ```lua
+            print(mq.TLO.FindItemBank("=Water Sprinkler of Nem Ankh").ID())
+            ```
+
+
+[item]: ../data-types/datatype-item.md

--- a/reference/top-level-objects/tlo-finditembankcount.md
+++ b/reference/top-level-objects/tlo-finditembankcount.md
@@ -4,17 +4,50 @@ tags:
 ---
 # `FindItemBankCount`
 
-Count of items in bank by partial name match. Using =name will find the exact match only.
+A TLO used to find a count of items in your bank by partial or exact name match. _See examples below._
 
 ## Forms
 
-|  |  |
-| :--- | :--- |
-| [_int_](../data-types/datatype-int.md) **FindItemBankCount[**name**]** | Count of items in bank by partial name match |
-| [_int_](../data-types/datatype-int.md) **FindItemBankCount[**=name**]** | Count of items in bank by exact name match |
+[_item_][item] **FindItemBankCount**[_name/id_]
 
-## Examples
+:   Counts the items in your bank using the given item id, or partial name match.
 
-`/echo ${FindItemBankCount[=Swirling Shadows]}`
+    ??? example
 
-Returns how many Swirling Shadows you have in your bank
+        Echos the number of items in your bank with the name swirling in it.
+
+        === "MQScript"
+
+            ```
+            /echo ${FindItemBankCount[swirling]}
+            ```
+
+        === "Lua"
+
+            ```lua
+            print(mq.TLO.FindItemBankCount("swirling"))
+            ```
+
+
+[_item_][item] **FindItemBankCount**[=_name_]
+
+:   Counts the items in your bank using exact name match (case insensntive).
+
+    ??? example
+
+        Echoes the number of Swirling Shadows you have in your bank.
+
+        === "MQScript"
+
+            ```
+            /echo ${FindItemBankCount[=Swirling Shadows]}
+            ```
+
+        === "Lua"
+
+            ```lua
+            print(mq.TLO.FindItemBankCount("=Swirling Shadows"))
+            ```
+
+
+[item]: ../data-types/datatype-item.md

--- a/reference/top-level-objects/tlo-finditemcount.md
+++ b/reference/top-level-objects/tlo-finditemcount.md
@@ -4,21 +4,52 @@ tags:
 ---
 # `FindItemCount`
 
-Count of items on character by partial name match. Using =name will find an exact match only.
+A TLO used to find a count of items on your character, corpse, or a merchant by partial or exact name match. _See examples below._
 
 ## Forms
 
-|  |  |
-| :--- | :--- |
-| [_int_](../data-types/datatype-int.md) **FindItemCount[**name**]** | Count of items on character by partial name match |
-| [_int_](../data-types/datatype-int.md) **FindItemCount[**=name**]** | Count of items on character by exact name match |
+[_item_][item] **FindItemCount**[_name/id_]
 
-## Examples
+:   Counts the items using the given item id, or partial name match. Will search character
+    inventory and any items stored in key rings (illusion, mount, etc).
 
-`/echo ${FindItemCount[=Water Flask]}`
+    ??? example
 
-Echoes the number of Water Flasks you have in your inventory.
+        Echos the number of items in your inventory with the name swirling in it.
 
-`/echo ${FindItemCount["=${SomeItem}"]}`
+        === "MQScript"
 
-Echoes the number of an item as defined by a string. Note the placement of the quotes, it is important.
+            ```
+            /echo ${FindItemCount[swirling]}
+            ```
+
+        === "Lua"
+
+            ```lua
+            print(mq.TLO.FindItemCount("swirling"))
+            ```
+
+
+[_item_][item] **FindItemCount**[=_name_]
+
+:   Counts the items using exact name match (case insensntive). Will search character inventory
+    and any items stored in key rings (illusion, mount, etc).
+
+    ??? example
+
+        Echoes the number of Water Flasks you have in your inventory.
+
+        === "MQScript"
+
+            ```
+            /echo ${FindItemCount[=Water Flask]}
+            ```
+
+        === "Lua"
+
+            ```lua
+            print(mq.TLO.FindItemCount("=Water Flask"))
+            ```
+
+
+[item]: ../data-types/datatype-item.md


### PR DESCRIPTION
Update tlo-finditemcount/finditembank/finditembankcount to the latest standards, and include information about using the item ID instead of a item Name.