### PR TITLE
Update window datatype documentation using new format

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
       - plugins/core-plugins/mq2custombinds/README.md
 
       - /custombind: plugins/core-plugins/mq2custombinds/custombind.md
+
     - MQ2EQBugFix: plugins/core-plugins/mq2eqbugfix.md
     - MQ2HUD:
       - plugins/core-plugins/mq2hud/README.md
@@ -297,7 +298,6 @@ nav:
       - /click: reference/commands/click.md
       - /combine: reference/commands/combine.md
       - /ctrlkey: reference/commands/ctrlkey.md
-      - /custombind: reference/commands/custombind.md
       - /destroy: reference/commands/destroy.md
       - /docommand: reference/commands/docommand.md
       - /doors: reference/commands/doors.md

--- a/reference/data-types/datatype-argb.md
+++ b/reference/data-types/datatype-argb.md
@@ -8,27 +8,27 @@ Represents a color
 
 ## Members
 
-[_int_][int] **A**
+### [int][int] `A`
 
 :   Alpha channel value.
 
-[_int_][int] **R**
+### [int][int] `R`
 
 :   Red color value.
 
-[_int_][int] **G**
+### [int][int] `G`
 
 :   Green color value.
 
-[_int_][int] **B**
+### [int][int] `B`
 
 :   Blue color value.
 
-[_int_][int] **Int**
+### [int][int] `Int`
 
 :   The integer formed by the ARGB.
 
-[_string_][string] **(To String)**
+### [string][string] To String
 
 :   The hex value of the integer formed by the ARGB.
 

--- a/reference/data-types/datatype-character.md
+++ b/reference/data-types/datatype-character.md
@@ -235,6 +235,7 @@ If something is missing here, you can check the source to see if it exists.
 | | **McKenzie** | |
 | | **MedalsOfConflict** | |
 | | **MedalsOfHeroism** | |
+| [_string_](datatype-string.md) | **MembershipLevel** | Account membership level: `GOLD`, `SILVER`, `FREE`. All-Access and Lifetime All-access are both considered Gold. |
 | [_int64_](datatype-int64.md) | **MercAAExp** | |
 | | **MercAAPoints* | |
 | | **MercAAPointsSpent** | |
@@ -325,7 +326,7 @@ If something is missing here, you can check the source to see if it exists.
 | [_int_](datatype-int.md) | **StrikeThroughBonus** | Strikethrough bonus from gear and spells |
 | [_bool_](datatype-bool.md) | **Stunned** | Am I stunned? |
 | [_int_](datatype-int.md) | **StunResistBonus** | Stun Resist bonus from gear and spells |
-| [_string_](datatype-string.md) | **Subscription** | Subscription type GOLD, FREE, (Silver?) |
+| [_string_](datatype-string.md) | **Subscription** | See MembershipLevel |
 | [_int_](datatype-int.md) | **SubscriptionDays** | The number of days left before subscription expires. |
 | | **SV** | |
 | [_int_](datatype-int.md) | **svChromatic** | Your character's lowest resist |

--- a/reference/data-types/datatype-window.md
+++ b/reference/data-types/datatype-window.md
@@ -10,66 +10,420 @@ Windows come in many forms, but all are represented with the generic **window** 
 
 ## Members
 
-| **Type**                           | **Member**                      | **Description**                                                                                                                                                                                          |
-| ---------------------------------- | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [_argb_](datatype-argb.md)         | **BGColor**                     | Background color                                                                                                                                                                                         |
-| [_bool_](datatype-bool.md)         | **Checked**                     | Returns TRUE if the button has been checked                                                                                                                                                              |
-| [_window_](datatype-window.md)     | **Child**[_name_]               | Find a child window with the provided name                                                                                                                                                               |
-| [_bool_](datatype-bool.md)         | **Children**                    | Returns TRUE if the window has children                                                                                                                                                                  |
-| [_window_](datatype-window.md)     | **CurrentTab**                  | `TabBox`: Returns the `Page` window associated with the currently selected tab.                                                                                                                          |
-| [_int_](datatype-int.md)           | **CurrentTabIndex**             | `TabBox`: Returns the index of the currently selected tab.                                                                                                                                               |
-| [_bool_](datatype-bool.md)         | **Enabled**                     | Returns TRUE if the window is enabled                                                                                                                                                                    |
-| [_window_](datatype-window.md)     | **FirstChild**                  | First child window                                                                                                                                                                                       |
-| [_int_](datatype-int.md)           | **GetCurSel**                   | Index of the currently selected/highlighted item in a list or treeview                                                                                                                                   |
-| [_int_](datatype-int.md)           | **Height**                      | Height in pixels                                                                                                                                                                                         |
-| [_bool_](datatype-bool.md)         | **Highlighted**                 | Returns TRUE if the window is highlighted                                                                                                                                                                |
-| [_bool_](datatype-bool.md)         | **HisTradeReady**               | Has the other person clicked the Trade button?                                                                                                                                                           |
-| [_int_](datatype-int.md)           | **HScrollMax**                  | Horizontal scrollbar range                                                                                                                                                                               |
-| [_int_](datatype-int.md)           | **HScrollPos**                  | Horizontal scrollbar position                                                                                                                                                                            |
-| [_int_](datatype-int.md)           | **HScrollPct**                  | Horizontal scrollbar position in % to range from 0 to 100                                                                                                                                                |
-| [_int_](datatype-int.md)           | **Items**                       | Number of items in a Listbox or Combobox                                                                                                                                                                 |
-| [_string_](datatype-string.md)     | **List**[_N_,_y_]               | Get the text for the _Nth_ item in a list box. Only works on list boxes. Use of _y_ is optional and allows selection of the column of the window to get text from.                                       |
-| [_int_](datatype-int.md)           | **List**[_text_,_y_]            | Find an item in a list box by partial match (use **window.List**[=_text_] for exact). Only works on list boxes. Use of _y_ is optional and allows selection of the column of the window to search in.    |
-| [_bool_](datatype-bool.md)         | **Minimized**                   | Returns TRUE if the window is minimized                                                                                                                                                                  |
-| [_bool_](datatype-bool.md)         | **MouseOver**                   | Returns TRUE if the mouse is currently over the window                                                                                                                                                   |
-| [_bool_](datatype-bool.md)         | **MyTradeReady**                | Have I clicked the Trade button?                                                                                                                                                                         |
-| [_string_](datatype-string.md)     | **Name**                        | Name of window piece, _e.g._ "ChatWindow" for top level windows, or the piece name for child windows.<br/><br/>_Note: this is custom ui dependent_                                                       |
-| [_window_](datatype-window.md)     | **Next**                        | Next sibling window                                                                                                                                                                                      |
-| [_bool_](datatype-bool.md)         | **Open**                        | Returns TRUE if the window is open                                                                                                                                                                       |
-| [_window_](datatype-window.md)     | **Parent**                      | Parent window                                                                                                                                                                                            |
-| [_string_](datatype-string.md)     | **ScreenID**                    | ScreenID of window piece.<br/><br/>_Note: This is **not** custom ui dependent, it must be the same on all UIs_                                                                                           |
-| [_bool_](datatype-bool.md)         | **Siblings**                    | Returns TRUE if the window has siblings                                                                                                                                                                  |
-| [_int_](datatype-int.md)           | **Style**                       | Window style code                                                                                                                                                                                        |
-| [_int_](datatype-int.md)           | **TabCount**                    | `TabBox`: The number of tabs present in the TabBox.                                                                                                                                                      |
-| [_window_](datatype-window.md)     | **Tab** [_#/Name_]              | `TabBox`: Looks up the `Page` window that matches the provided index or tab text.                                                                                                                        |
-| [_string_](datatype-string.md)     | **Text**                        | Window's text.<br/><br/>`STMLBox`: returns the contents of the STML.<br/>`Page`: returns the name of the page's Tab.                                                                                     |
-| [_string_](datatype-string.md)     | **Tooltip**                     | TooltipReference text                                                                                                                                                                                    |
-| [_string_](datatype-string.md)     | **Type**                        | Type of window piece (Screen for top level windows, or Listbox, Button, Gauge, Label, Editbox, Slider, etc)                                                                                              |
-| [_int_](datatype-int.md)           | **VScrollMax**                  | Vertical scrollbar range                                                                                                                                                                                 |
-| [_int_](datatype-int.md)           | **VScrollPct**                  | Vertical scrollbar position in % to range from 0 to 100                                                                                                                                                  |
-| [_int_](datatype-int.md)           | **VScrollPos**                  | Vertical scrollbar position                                                                                                                                                                              |
-| [_int_](datatype-int.md)           | **Width**                       | Width in pixels                                                                                                                                                                                          |
-| [_int_](datatype-int.md)           | **X**                           | Screen X position                                                                                                                                                                                        |
-| [_int_](datatype-int.md)           | **Y**                           | Screen Y position                                                                                                                                                                                        |
-| [_string_](datatype-string.md)     | **To String**                   | TRUE if window exists, FALSE if not                                                                                                                                                                      |
+
+### [argb][argb] `BGColor`
+
+:   Background color of the window.
+
+
+### [bool][bool] `Checked`
+
+:   Returns `TRUE` if the button has been checked.
+
+
+### [window](datatype-window.md) `Child[name]`
+
+:   Find a child window with the provided name.
+
+    Parameters:
+
+    *   `name`: Name of a child window
+
+
+### [bool][bool] `Children`
+
+:   Returns `TRUE` if the window has children.
+
+
+### [window](datatype-window.md) `CurrentTab`
+
+:   Applies to: `TabBox`
+
+    Returns the `Page` window associated with the currently selected tab.
+
+
+### [int][int] `CurrentTabIndex`
+
+:   Applies to: `TabBox`
+
+    Returns the index of the currently selected tab.
+
+
+### [bool][bool] `Enabled`
+
+:   Returns `TRUE` if the window is enabled.
+
+
+### [window](datatype-window.md) `FirstChild`
+
+:   Returns the first child window in the window hierarchy.
+
+
+### [int][int] `GetCurSel`
+
+:   !!! info "Deprecation Notice"
+
+        This member is deprecated and discouraged from continued use. Please use [SelectedIndex](#int-selectedindex) instead.
+
+    Applies to: `Combobox`, `Listbox`, `TreeView`
+
+    Index of the currently selected/higlighted item.
+
+
+### [int][int] `Height`
+
+:   Height of the window in pixels.
+
+
+### [bool][bool] `Highlighted`
+
+:   Returns `TRUE` if the window is the currently focused window.
+
+
+### [bool][bool] `HisTradeReady`
+
+:   Returns the following data from the trade window, regardless of what the current window object is:
+
+    Has the other person clicked the Trade button?
+
+
+### [int][int] `HScrollMax`
+
+:   Horizontal scrollbar maximum position.
+
+
+### [int][int] `HScrollPct`
+
+:   Horizontal scroll bar current position as a percentage of the maximum position as a value from 0 to 100.
+
+
+### [int][int] `HScrollPos`
+
+:   Horizontal scroll bar current position.
+
+
+### [int][int] `Items`
+
+:   Applies to: `Combobox`, `Listbox`, `TreeView`
+
+    Number of items in the list.
+
+
+### [string][string] `List[Row,Col]`
+
+:   Applies to: `Combobox`, `Listbox`, `TreeView`
+
+    Get text for an item in the list by the specified row and column. If the column is not provided then the first column is used.
+
+    Parameters:
+
+    *   `Row`: Row index of the item in the list.
+    *   `Col`: _[optional]_ Column index of the item in the list.
+
+
+### [int][int] `List[Text,Col]`
+
+:   Applies to: `Combobox`, `Listbox`, `TreeView`
+
+    Search a list for an item by text. Returns the index of the first element that matches the given text string.
+
+    Parameters:
+
+    *   `Text`: Text to search for. Partial match is performed. Prefix with `=` to perform an exact match.
+    *   `Col`: _[optional]_ Column index of the item in the item in the list. If not provided, the first column is searched.
+
+
+### [bool][bool] `Minimized`
+
+:   Returns `TRUE` if the window is minimized.
+
+
+### [bool][bool] `MouseOver`
+
+:   Returns `TRUE` if the mouse is currently over the window.
+
+
+### [bool][bool] `MyTradeReady`
+
+:   Returns the following data from the trade window, regardless of what the current window object is:
+
+    Have I clicked the Trade button?
+
+
+### [string][string] `Name`
+
+:   Name of the window.
+
+    _Note: this value may be affected by custom ui._
+
+
+### [window](datatype-window.md) `Next`
+
+:   Next sibling window in the window hierarchy.
+
+
+### [bool][bool] `Open`
+
+:   Returns `TRUE` if the window is open.
+
+
+### [window](datatype-window.md) `Parent`
+
+:   Returns the parent of this window, or `NULL` if this is a top level window.
+
+
+### [string][string] `ScreenID`
+
+:   ScreenID of the window piece.
+
+    _Note: This is **not** custom ui dependent, it must be the same on all UIs._
+
+
+### [int][int] `SelectedIndex`
+
+:   Applies to: `Combobox`, `Listbox`, `TreeView`
+
+    Index of the currently selected/higlighted item.
+
+
+### [bool][bool] `Siblings`
+
+:   Returns `TRUE` if the window has siblings.
+
+
+### [int][int] `Style`
+
+:   Returns an integer representing the window style bit flags.
+
+
+### [int][int] `TabCount`
+
+:   Applies to: `TabBox`
+
+    The number of tabs present in the TabBox.
+
+
+### [window](datatype-window.md) `Tab[Index]`
+
+:   Applies to: `TabBox`
+
+    Looks up the `Page` window that matches the provided tab index in the TabBox.
+
+
+### [window](datatype-window.md) `Tab[Text]`
+
+:   Applies to: `TabBox`
+
+    Looks up the `Page` window that matches the provided tab text in the TabBox.
+
+
+### [string][string] `Text`
+
+:   The text of the window. The actual value varies by type of window:
+
+    *   `STMLbox`: Returns the contents of the STML.
+    *   `Page`: Returns the name of the page's Tab.
+
+
+### [string][string] `Tooltip`
+
+:   The tooltip text for the window. This value comes from the window's TooltipReference.
+
+
+### [string][string] `Type`
+
+:   The window's type. The type will determine the behavior of some of the other members.
+
+    Can be one of:
+
+    * `Screen`
+    * `Listbox`
+    * `Gauge`
+    * `SpellGem`
+    * `InvSlot`
+    * `Editbox`
+    * `Slider`
+    * `Label`
+    * `STMLbox`
+    * `TreeView`
+    * `Combobox`
+    * `Page`
+    * `TabBox`
+    * `LayoutBox`
+    * `HorizontalLayoutBox`
+    * `VerticalLayoutBox`
+    * `FinderBox`
+    * `TileLayoutBox`
+    * `Screen`
+    * `HotButton`
+
+
+### [int][int] `VScrollMax`
+
+:   Vertical scrollbar maximum position.
+
+
+### [int][int] `VScrollPct`
+
+:   Vertical scroll bar current position as a percentage of the maximum position as a value from 0 to 100.
+
+
+### [int][int] `VScrollPos`
+
+:   Vertical scroll bar current position.
+
+
+### [int][int] `Width`
+
+:   Width of the window in pixels.
+
+
+### [int][int] `X`
+
+:   The X coordinate of the window's position, in pixels.
+
+
+### [int][int] `Y`
+
+:   The Y coordinate of the window's position, in pixels.
+
+
+### [string][string] To String
+
+:   `TRUE` if the window is open, `FALSE` if not, matching [Open](#bool-open)
+
 
 ## Methods
 
-| **Name**                            | Action                                                              |
-| ----------------------------------- | ------------------------------------------------------------------- |
-| **DoClose**                         | Does the action of closing a window                                 |
-| **DoOpen**                          | Does the action of opening a window                                 |
-| **LeftMouseDown**                   | Does the action of clicking the left mouse button down              |
-| **LeftMouseHeld**                   | Does the action of holding the left mouse button                    |
-| **LeftMouseHeldUp**                 | does the action of holding the left mouse button up                 |
-| **LeftMouseUp**                     | Does the action of clicking the left mouse button up                |
-| **RightMouseDown**                  | does the action of clicking the right mouse button                  |
-| **RightMouseHeld**                  | Does the action of holding the right mouse button                   |
-| **RightMouseHeldUp**                | Does the action of holding the right mouse button up                |
-| **RightMouseUp**                    | Does the action of clicking the right mouse button up               |
-| **Select**                          | Selects the specified window                                        |
-| **SetCurrentTab** [ _# or Name_ ]   | If the window is a TabBox, set the current tab by index or by name. |
-| **SetText** [ _text_ ]              | If the window is an EditBox, set the current text.                  |
+
+### `DoClose`
+
+:   Close the window. Has the effect of hiding the window if it closed.
+
+
+### `DoOpen`
+
+:   Open the window. Has the effect of showing the window if it is hidden.
+
+
+### `LeftMouseDown`
+
+:   Send a `leftmousedown` event to the window.
+
+    Has the same effect as using the [/notify](../commands/notify.md) command on the window.
+
+
+### `LeftMouseHeld`
+
+:   Send a `leftmouseheld` event to the window.
+
+    Has the same effect as using the [/notify](../commands/notify.md) command on the window.
+
+### `LeftMouseHeldUp`
+
+:   Send a `leftmouseheldup` event to the window.
+
+    Has the same effect as using the [/notify](../commands/notify.md) command on the window.
+
+
+### `LeftMouseUp`
+
+:   Send a `leftmouseup` event to the window.
+
+    Has the same effect as using the [/notify](../commands/notify.md) command on the window.
+
+
+### `Move[X,Y,Width,Height]`
+
+:   Move or resize the window.
+
+### `RightMouseDown`
+
+:   Send a `rightmousedown` event to the window.
+
+    Has the same effect as using the [/notify](../commands/notify.md) command on the window.
+
+
+### `RightMouseHeld`
+
+:   Send a `rightmouseheld` event to the window.
+
+    Has the same effect as using the [/notify](../commands/notify.md) command on the window.
+
+
+### `RightMouseHeldUp`
+
+:   Send a `rightmouseheldup` event to the window.
+
+    Has the same effect as using the [/notify](../commands/notify.md) command on the window.
+
+
+### `RightMouseUp`
+
+:   Send a `rightmouseup` event to the window.
+
+    Has the same effect as using the [/notify](../commands/notify.md) command on the window.
+
+
+### `Select[Index]`
+
+:   Applies to: `Combobox`, `Listbox`, `TreeView`
+
+    Selects the specified item in the list.
+
+    Parameters:
+
+    *   `Index`: The number index of the item to select
+
+
+### `SetAlpha[Alpha]`
+
+:   Set the alpha value for the window.
+
+    Parameters:
+    
+    *   `Alpha`: The alpha value, a number between 0 and 255.
+
+
+### `SetBGColor[Color]`
+
+:   Set the background color.
+
+    Parameters:
+    
+    *   `Color`: A hex string in the form "AARRGGBB"
+
+
+### `SetCurrentTab[Index]`
+
+:   Applies to: `TabBox`.
+
+    Changes the current tab of the tab box.
+
+    Parameters:
+
+    *   `Index`: Either the text or the index of the tab to select. If text is provided, it is case insensitive.
+
+
+### `SetFadeAlpha[Alpha]`
+
+:   Set the faded alpha value for the window.
+
+    Parameters:
+
+    *   `Alpha`: The alpha value, a number between 0 and 255.
+
+
+### `SetText[Text]`
+
+:   Applies to: `EditBox`
+
+    Changes the current text value of the edit box.
+
+    Parameters:
+
+    *   `Text`: The text to set to the edit box.
+
 
 ## Usage
 
@@ -112,3 +466,9 @@ Return TRUE if I have clicked the Trade button in the Trade Window (TradeWnd)
 `${Window[RewardSelectionWnd/RewardPageTabWindow].Tab[Brew for the Day].Child[RewardSelectionOptionList].List[2]}`
 
 Returns the name of the 2nd option in the list of rewards for the tab titled "Brew for the Day"
+
+
+[argb]: datatype-argb.md
+[bool]: datatype-bool.md
+[int]: datatype-int.md
+[string]: datatype-string.md


### PR DESCRIPTION
- Updated formatting of ARGB datatype documentation which already uses new format.
- Added MembershipLevel to character datatype.

We had talked about this new format for datatypes months ago. Finally got around to using it somewhere. What really makes is nice is that the members are now anchored on the right side, and there is more room to write additional details like parameters and criteria.

Screenshot:
![image](https://github.com/macroquest/docs/assets/57729/b5c94598-4726-45fc-9b43-4fdc4d958462)

It also makes it possible to search for members:
![image](https://github.com/macroquest/docs/assets/57729/08a7dbee-74e6-41f2-b990-282f7d2cf6d9)
