### PR TITLE
menu / filename consistency

### DIFF
--- a/main/plugin-quick-list.md
+++ b/main/plugin-quick-list.md
@@ -97,6 +97,4 @@ git clone -b master https://github.com/RedGuides/MQ2XAssist.git plugins/MQ2XAssi
 git clone -b master https://github.com/RedGuides/MQ2XPTracker.git plugins/MQ2XPTracker
 # Emu only
 git clone -b main https://github.com/Knightly1/MQMountClassicModels.git plugins/MQMountClassicModels
-# Update submodules of these submodules
-git submodule update --init --recursive
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,7 +25,7 @@ nav:
   - Getting Started: main/README.md
   - Building MacroQuest:
     - main/building.md
-    - Plugin Submodule Quick List: main/submodule-quick-list.md
+    - Plugin Repository Quick List: main/plugin-quick-list.md
 
   - Features:
     - Anonymize: main/features/anonymize.md


### PR DESCRIPTION
Make menu name match updated page name.
Remove no longer useful command from instructions.