### PR TITLE
Create color-codes.md

### DIFF
--- a/reference/general/color-codes.md
+++ b/reference/general/color-codes.md
@@ -1,0 +1,33 @@
+## Color Codes
+
+`\ab = black`  
+`\a-b = black (dark)`
+
+`\ag = green`  
+`\a-g = green (dark)`
+
+`\am = magenta`  
+`\a-m = magenta (dark)`
+
+`\ao = orange`  
+`\a-o = orange (dark)`
+
+`\ap = purple`  
+`\a-p = purple (dark)`
+
+`\ar = red`  
+`\a-r = red (dark)`
+
+`\at = cyan`  
+`\a-t = cyan (dark)`
+
+`\au = blue`  
+`\a-u = blue (dark)`
+
+`\aw = white`  
+`\a-w = white (dark)`
+
+`\ay = yellow`  
+`\a-y = yellow (dark)`
+
+`\ax = previous color (if no previous \a? this would be the default mq2 color)`


### PR DESCRIPTION
Add Color codes to the general information subsection of the reference section. It took me a while to find the color codes, and I found them in the echo command entry. I think this would be a more suitable place for them, with /echo being useless in lua because of print/printf.