### PR TITLE
adding an "eqcommand" lexer

### DIFF
--- a/.github/workflows/mkdocs_deploy.yml
+++ b/.github/workflows/mkdocs_deploy.yml
@@ -32,6 +32,7 @@ jobs:
           pip install mkdocs-same-dir
           pip install python-markdown-math
           pip install mkdocs-macros-plugin
+          pip install eq_lexers
       - name: Configure git as github-actions bot
         run: git config user.name 'github-actions[bot]' && git config user.email 'github-actions[bot]@users.noreply.github.com'
       - name: Publish docs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -661,7 +661,8 @@ markdown_extensions:
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
-  - pymdownx.highlight
+  - pymdownx.highlight:
+      pygments_lang_class: true
   - pymdownx.inlinehilite
   - pymdownx.keys
   - pymdownx.mark

--- a/reference/commands/aa.md
+++ b/reference/commands/aa.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/aa [list (all | timers)] [info** _abilityname_ **] [act** _abilityname_ **]**
+```eqcommand
+/aa [list (all | timers)] [info <abilityname> ] [act <abilityname> ]
+```
 
 ## Description
 

--- a/reference/commands/advloot.md
+++ b/reference/commands/advloot.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/advloot {personal | shared} {set |** _"item name"_ **|** _#index_ **}** _window option_ **[** _quantity_ **]**
+```eqcommand
+/advloot {personal | shared} {set | <"item name"> | <#index> } <window option> [ <quantity> ]
+```
 
 ## Description
 

--- a/reference/commands/alert.md
+++ b/reference/commands/alert.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/alert { add | remove | clear | list }** _#list_ **[** _Spawn Search_ **]**
+```eqcommand
+/alert { add | remove | clear | list } <#list> [ <Spawn Search> ]
+```
 
 ## Description
 

--- a/reference/commands/alias.md
+++ b/reference/commands/alias.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/alias** _aliasname_ _command_ **| [list | reload |** _aliasname_ **delete]**
+```eqcommand
+/alias <aliasname> <command> | [list | reload | <aliasname> delete]
+```
 
 ## Description
 Creates custom command shortcuts. Aliases are saved in MacroQuest.ini and persist between sessions.

--- a/reference/commands/altkey.md
+++ b/reference/commands/altkey.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/altkey** _command_
+```eqcommand
+/altkey <command>
+```
 
 ## Description
 

--- a/reference/commands/banklist.md
+++ b/reference/commands/banklist.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/banklist**
+```eqcommand
+/banklist
+```
 
 ## Description
 

--- a/reference/commands/beep.md
+++ b/reference/commands/beep.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/beep** [ _filename_ ]
+```eqcommand
+/beep [ <filename> ]
+```
 
 ## Description
 

--- a/reference/commands/beepontells.md
+++ b/reference/commands/beepontells.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/beepontells [on|off]**
+```eqcommand
+/beepontells [on|off]
+```
 
 ## Description
 

--- a/reference/commands/benchmark.md
+++ b/reference/commands/benchmark.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/benchmark [**_command_**]**
+```eqcommand
+/benchmark [<command>]
+```
 
 ## Description
 

--- a/reference/commands/bind.md
+++ b/reference/commands/bind.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/bind [~]**_name_ **[** _keycombo_ **| clear] | [list | eqlist]**
+```eqcommand
+/bind [~]<name> [ <keycombo> | clear] | [list | eqlist]
+```
 
 ## Description
 

--- a/reference/commands/break.md
+++ b/reference/commands/break.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/break**
+```eqcommand
+/break
+```
 
 ## **Description**
 

--- a/reference/commands/buyitem.md
+++ b/reference/commands/buyitem.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/buyitem** [_quantity_]
+```eqcommand
+/buyitem [<quantity>]
+```
 
 ## Description
 

--- a/reference/commands/cachedbuffs.md
+++ b/reference/commands/cachedbuffs.md
@@ -7,7 +7,9 @@ tags:
 
 ## Syntax
 
-**/cachedbuffs [cleartarget|reset]**
+```eqcommand
+/cachedbuffs [cleartarget|reset]
+```
 
 ## Description
 

--- a/reference/commands/call.md
+++ b/reference/commands/call.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/call** _**subroutine**_ **[Param0... \[Param\#\]]**
+```eqcommand
+/call <subroutine> [Param0... \[Param\#\]]
+```
 
 ### Description
 

--- a/reference/commands/call.md
+++ b/reference/commands/call.md
@@ -7,7 +7,7 @@ tags:
 ## Syntax
 
 ```eqcommand
-/call <subroutine> [Param0... \[Param\#\]]
+/call <subroutine> [Param0... [Param#]]
 ```
 
 ### Description

--- a/reference/commands/caption.md
+++ b/reference/commands/caption.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/caption list | update** _#_ **| MQCaptions [on|off] | reload | _type_** _value_ 
+```eqcommand
+/caption list | update <#> | MQCaptions [on|off] | reload | <type> <value> 
+```
 
 ## Description
 

--- a/reference/commands/captioncolor.md
+++ b/reference/commands/captioncolor.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/captioncolor list |** _"name"_ **[ off | on |**  _r g b_ **]**
+```eqcommand
+/captioncolor list | <"name"> [ off | on |  <r g b> ]
+```
 
 ## Description
 

--- a/reference/commands/cast.md
+++ b/reference/commands/cast.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/cast [ list |** _"spellname"_ **| item** _"itemname"_ **] [ loc** _x y z_ **]**
+```eqcommand
+/cast [ list | <"spellname"> | item <"itemname"> ] [ loc <x y z> ]
+```
 
 ## Description
 

--- a/reference/commands/cecho.md
+++ b/reference/commands/cecho.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/cecho** _**text**_
+```eqcommand
+/cecho <text>
+```
 
 ## Description
 

--- a/reference/commands/char.md
+++ b/reference/commands/char.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/char**
+```eqcommand
+/char
+```
 
 ## Description
 

--- a/reference/commands/cleanup.md
+++ b/reference/commands/cleanup.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/cleanup**
+```eqcommand
+/cleanup
+```
 
 ## Description
 

--- a/reference/commands/clearerrors.md
+++ b/reference/commands/clearerrors.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/clearerrors**
+```eqcommand
+/clearerrors
+```
 
 ## Description
 

--- a/reference/commands/click.md
+++ b/reference/commands/click.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/click [ left | right ] [ target | item | door | switch | center |** _x_ _y_ **]**
+```eqcommand
+/click [ left | right ] [ target | item | door | switch | center | <x> <y> ]
+```
 
 ## Description
 

--- a/reference/commands/combine.md
+++ b/reference/commands/combine.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/combine pack\#**
+```eqcommand
+/combine pack<#>
+```
 
 ## Description
 

--- a/reference/commands/continue.md
+++ b/reference/commands/continue.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/continue**
+```eqcommand
+/continue
+```
 
 ## Description
 

--- a/reference/commands/convertitem.md
+++ b/reference/commands/convertitem.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/convertitem** _item name_
+```eqcommand
+/convertitem <"item name">
+```
 
 ## Description
 Triggers convert on the item.

--- a/reference/commands/crash.md
+++ b/reference/commands/crash.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/crash [force]**
+```eqcommand
+/crash [force]
+```
 
 ## Description
 Create a synthetic crash for debugging purposes.

--- a/reference/commands/ctrlkey.md
+++ b/reference/commands/ctrlkey.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/ctrlkey** _command_
+```eqcommand
+/ctrlkey <command>
+```
 
 ## Description
 

--- a/reference/commands/declare.md
+++ b/reference/commands/declare.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/declare** _varname_ **|** _varname[array extents]_ **[** _type_ **]** **[ local | global | outer ]** **[** _defaultvalue_ **]**
+```eqcommand
+/declare <varname> | <varname[array extents]> [ <type> ] [ local | global | outer ] [ <defaultvalue> ]
+```
 
 ## Description
 

--- a/reference/commands/delay.md
+++ b/reference/commands/delay.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/delay** _#_**[s|m]** **[** _condition_ **]**
+```eqcommand
+/delay <#>[s|m] [ <condition> ]
+```
 
 ## Description
 

--- a/reference/commands/delay.md
+++ b/reference/commands/delay.md
@@ -7,14 +7,14 @@ tags:
 ## Syntax
 
 ```eqcommand
-/delay <#>[s|m] [ <condition> ]
+/delay <#deciseconds>[s|m] [ <condition> ]
 ```
 
 ## Description
 
 Fully pauses the macro for the amount of time specified, or until _condition_ is met.
 
-Time can be specified in 10ths of a second (a number by itself\) or in seconds \(number followed by an "s"\) or minutes \(number followed by "m").
+Time can be specified in 10ths of a second (a number by itself) or in seconds (number followed by an "s") or minutes (number followed by "m").
 
 ## Examples
 

--- a/reference/commands/deletevar.md
+++ b/reference/commands/deletevar.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/deletevar** _varname_ [**\* global**]
+```eqcommand
+/deletevar <varname> [\* global]
+```
 
 ## Description
 

--- a/reference/commands/deletevar.md
+++ b/reference/commands/deletevar.md
@@ -7,7 +7,7 @@ tags:
 ## Syntax
 
 ```eqcommand
-/deletevar <varname> [\* global]
+/deletevar <varname> [* global]
 ```
 
 ## Description

--- a/reference/commands/destroy.md
+++ b/reference/commands/destroy.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/destroy**
+```eqcommand
+/destroy
+```
 
 ## Description
 

--- a/reference/commands/doability.md
+++ b/reference/commands/doability.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/doability** [**list** | _ability_]
+```eqcommand
+/doability [list | <ability>]
+```
 
 ## Description
 Extends EverQuest's doability command (/doability 1-10) to list available abilities and perform them by name or ID. 

--- a/reference/commands/docommand.md
+++ b/reference/commands/docommand.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/docommand** _command_
+```eqcommand
+/docommand <command>
+```
 
 ## Description
 

--- a/reference/commands/doevents.md
+++ b/reference/commands/doevents.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/doevents [ flush ] [** _specificevent_ **]**
+```eqcommand
+/doevents [ flush ] [ <specificevent> ]
+```
 
 ## Description
 

--- a/reference/commands/doors.md
+++ b/reference/commands/doors.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/doors [** _filter_ **]**
+```eqcommand
+/doors [ <filter> ]
+```
 
 ## Description
 

--- a/reference/commands/doortarget.md
+++ b/reference/commands/doortarget.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/doortarget [ clear | id** _#_ **|** _name_ **]**
+```eqcommand
+/doortarget [ clear | id <#> | <name> ]
+```
 
 ## Description
 

--- a/reference/commands/dosocial.md
+++ b/reference/commands/dosocial.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/dosocial [ list |** _social name_ **]**
+```eqcommand
+/dosocial [ list | <social name> ]
+```
 
 ## Description
 

--- a/reference/commands/drop.md
+++ b/reference/commands/drop.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/drop**
+```eqcommand
+/drop
+```
 
 ## Description
 

--- a/reference/commands/dumpbinds.md
+++ b/reference/commands/dumpbinds.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/dumpbinds** [ _filename_ ]
+```eqcommand
+/dumpbinds [ <filename> ]
+```
 
 ## Description
 

--- a/reference/commands/dumpstack.md
+++ b/reference/commands/dumpstack.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/dumpstack**
+```eqcommand
+/dumpstack
+```
 
 ## Description
 For debugging macroscript, outputs the current macro call stack

--- a/reference/commands/echo.md
+++ b/reference/commands/echo.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/echo** _text_
+```eqcommand
+/echo <text>
+```
 
 ## Description
 
@@ -61,3 +63,6 @@ span[style*="#00FFFF"] { color: #00FFFF !important; }
 |------|--------------------------------------|
 | `\n` | Newline                              |
 | `\d` | Down (same as newline, LamahHerder knows not why) |
+
+## See also
+* [/cecho](cecho.md)

--- a/reference/commands/endmacro.md
+++ b/reference/commands/endmacro.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/endmacro**
+```eqcommand
+/endmacro
+```
 
 ## Description
 

--- a/reference/commands/engine.md
+++ b/reference/commands/engine.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/engine** _type version_ **[noauto]** 
+```eqcommand
+/engine <type version> [noauto] 
+```
 
 ## Description
 Allows for switching engines. Full documentation at [https://gitlab.com/Knightly1/mq2-parser-changes](https://gitlab.com/Knightly1/mq2-parser-changes)

--- a/reference/commands/eqtarget.md
+++ b/reference/commands/eqtarget.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/eqtarget** _name_ **| group** _1-6_
+```eqcommand
+/eqtarget <name> | group <1-6>
+```
 
 ## Description
 

--- a/reference/commands/exec.md
+++ b/reference/commands/exec.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/exec** _command_ **[** _parameters_ **| bg] [bg]**
+```eqcommand
+/exec <command> [ <parameters> | bg] [bg]
+```
 
 ## Description
 

--- a/reference/commands/executelink.md
+++ b/reference/commands/executelink.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/executelink** _&lt;link text&gt;_
+```eqcommand
+/executelink <link text>
+```
 
 ## Description
 Simulates clicking on formatted link text.

--- a/reference/commands/face.md
+++ b/reference/commands/face.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/face [predict] [fast] [nolook] [away] [ loc** _y,x[,z]_ **| heading** _angle_ **| item | door|switch | id** _#_ **|** _Spawn Search_ **]**
+```eqcommand
+/face [predict] [fast] [nolook] [away] [ loc <y,x[,z]> | heading <angle> | item | door|switch | id <#> | <Spawn Search> ]
+```
 
 ## Description
 

--- a/reference/commands/filter.md
+++ b/reference/commands/filter.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/filter [macros {all|enhanced|none}] [skills {all|increase|none}] [target|money|food|encumber|debug {on|off}] [name {add|remove}** _text_ **] [zrange** _#_ **] [mq {on|off}]**
+```eqcommand
+/filter [macros {all|enhanced|none}] [skills {all|increase|none}] [target|money|food|encumber|debug {on|off}] [name {add|remove} <text> ] [zrange <#> ] [mq {on|off}]
+```
 
 ## Description
 

--- a/reference/commands/flashontells.md
+++ b/reference/commands/flashontells.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/flashontells [on|off]**
+```eqcommand
+/flashontells [on|off]
+```
 
 ## Description
 

--- a/reference/commands/for.md
+++ b/reference/commands/for.md
@@ -7,14 +7,15 @@ tags:
 ### Syntax
 
 ```eqcommand
-/for <varname initial-value> to\|downto final-value [step <interval>]
+/for <varname> <initial-value> to|downto <final-value> [step <interval>]
+/next <varname>
 ```
 
-**/next** _**varname**_
+
 
 ## Description
 
-This runs all commands between the /for line and the /next line, after which it increments/decrements the _varname_ number (\#1\) by _step_ number \(\#3\) \(default is 1) before running through the commands again. It will keep doing this until the _varname_ number equals \#2. You can end a /for loop immediately with /break or try the next iteration with /continue.
+This runs all commands between the /for line and the /next line, after which it increments/decrements the _varname_ number (#1) by _step_ number (#3) \(default is 1) before running through the commands again. It will keep doing this until the _varname_ number equals #2. You can end a /for loop immediately with /break or try the next iteration with /continue.
 
 ### Examples
 

--- a/reference/commands/for.md
+++ b/reference/commands/for.md
@@ -6,7 +6,9 @@ tags:
 
 ### Syntax
 
-**/for** _**varname** initial-value_ **to\|downto** final-value **[step** _interval_**]**
+```eqcommand
+/for <varname initial-value> to\|downto final-value [step <interval>]
+```
 
 **/next** _**varname**_
 

--- a/reference/commands/foreground.md
+++ b/reference/commands/foreground.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/foreground**
+```eqcommand
+/foreground
+```
 
 ## Description
 

--- a/reference/commands/framelimiter.md
+++ b/reference/commands/framelimiter.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/framelimiter [COMMAND] {OPTIONS}**
+```eqcommand
+/framelimiter [COMMAND] {OPTIONS}
+```
 
 ## Description
 

--- a/reference/commands/getwintitle.md
+++ b/reference/commands/getwintitle.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/getwintitle**
+```eqcommand
+/getwintitle
+```
 
 ## Description
 

--- a/reference/commands/goto.md
+++ b/reference/commands/goto.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/goto** _**:labelname**_
+```eqcommand
+/goto <:labelname>
+```
 
 ## Description
 

--- a/reference/commands/goto.md
+++ b/reference/commands/goto.md
@@ -7,7 +7,7 @@ tags:
 ## Syntax
 
 ```eqcommand
-/goto <:labelname>
+/goto :<labelname>
 ```
 
 ## Description

--- a/reference/commands/help.md
+++ b/reference/commands/help.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/help macro**
+```eqcommand
+/help macro
+```
 
 ## Description
 

--- a/reference/commands/hotbutton.md
+++ b/reference/commands/hotbutton.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/hotbutton** _name_ **[**_color_**]** **[**_line_**:][**_cursor_**:]**_text_**]**
+```eqcommand
+/hotbutton <name> [<color>] [<line>:][<cursor>:]<text>]
+```
 
 ## Description
 

--- a/reference/commands/identify.md
+++ b/reference/commands/identify.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/identify**
+```eqcommand
+/identify
+```
 
 ## Description
 

--- a/reference/commands/if.md
+++ b/reference/commands/if.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/if (** _**formula**_ **) {**
+```eqcommand
+/if ( <formula> ) {
+```
 
 _**commands**_
 

--- a/reference/commands/if.md
+++ b/reference/commands/if.md
@@ -8,15 +8,11 @@ tags:
 
 ```eqcommand
 /if ( <formula> ) {
+<commands>
+} [ else [/if ( <formula> ) ] {
+<...>
+} ]
 ```
-
-_**commands**_
-
-**} [ else \[/if (**_**formula**_**)\] { ]**
-
-**...**
-
-**}**
 
 ## Description
 

--- a/reference/commands/ini.md
+++ b/reference/commands/ini.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/ini "filename" "keyname" "valuename" "value"**
+```eqcommand
+/ini "filename" "keyname" "valuename" "value"
+```
 
 ## Description
 

--- a/reference/commands/insertaug.md
+++ b/reference/commands/insertaug.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/insertaug [** _itemID_ **|** _"Item Name"_ **|** _slot1_ _slot2_ **]**
+```eqcommand
+/insertaug [ <itemID> | <"Item Name"> | <slot1> <slot2> ]
+```
 
 ## Description
 

--- a/reference/commands/invoke.md
+++ b/reference/commands/invoke.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/invoke ${TLO.[XXX].Action}**
+```eqcommand
+/invoke ${TLO.[XXX].Action}
+```
 
 ## Description
 

--- a/reference/commands/itemnotify.md
+++ b/reference/commands/itemnotify.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/itemnotify [** _slotname_ **|** _#_ **|** **in** _bag_ _slot#_ **|** _itemname_ **]** _notification_
+```eqcommand
+/itemnotify [ <slotname> | <#> | in <bag> <slot#> | <itemname> ] <notification>
+```
 
 ## Description
 

--- a/reference/commands/items.md
+++ b/reference/commands/items.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/items [**_**filter**_**]**
+```eqcommand
+/items [<filter>]
+```
 
 ## Description
 

--- a/reference/commands/itemslots.md
+++ b/reference/commands/itemslots.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/itemslots**
+```eqcommand
+/itemslots
+```
 
 ## Description
 

--- a/reference/commands/itemtarget.md
+++ b/reference/commands/itemtarget.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/itemtarget "**_**itemname**_**"**
+```eqcommand
+/itemtarget "<itemname>"
+```
 
 ## Description
 

--- a/reference/commands/keepkeys.md
+++ b/reference/commands/keepkeys.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/keepkeys [off|on]**
+```eqcommand
+/keepkeys [off|on]
+```
 
 ## Description
 

--- a/reference/commands/keypress.md
+++ b/reference/commands/keypress.md
@@ -5,7 +5,9 @@ tags:
 # /keypress
 
 ## Syntax
-**/keypress** _name_ **[hold|chat]**
+```eqcommand
+/keypress <name> [hold|chat]
+```
 
 ## Description
 Simulates key presses for keybinds (e.g. "jump", "forward"), virtual keyboard (e.g. "shift+b"), or direct chat window input. Does not physically press keys, making it safe for background operation.

--- a/reference/commands/listmacros.md
+++ b/reference/commands/listmacros.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/listmacros [**_filter_**]**
+```eqcommand
+/listmacros [<filter>]
+```
 
 ## Description
 

--- a/reference/commands/loadcfg.md
+++ b/reference/commands/loadcfg.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/loadcfg** _filename_
+```eqcommand
+/loadcfg <filename>
+```
 
 ## Description
 

--- a/reference/commands/loadspells.md
+++ b/reference/commands/loadspells.md
@@ -5,7 +5,9 @@ tags:
 # /loadspells
 
 ## Syntax
-**/loadspells** [list|"name"]
+```eqcommand
+/loadspells [list|<"name">]
+```
 
 ## Description
 Loads or lists saved spell sets. Similar to /memspellset, but it only memorizes the spellset if it's not already memorized. This command was part of MQ years before EQ was inspired to add /memspellset.

--- a/reference/commands/location.md
+++ b/reference/commands/location.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/location**
+```eqcommand
+/location
+```
 
 ## Description
 

--- a/reference/commands/loginname.md
+++ b/reference/commands/loginname.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/loginname**
+```eqcommand
+/loginname
+```
 
 ## Description
 

--- a/reference/commands/look.md
+++ b/reference/commands/look.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/look [**_angle_**]**
+```eqcommand
+/look [<angle>]
+```
 
 ## Description
 

--- a/reference/commands/lootall.md
+++ b/reference/commands/lootall.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/lootall**
+```eqcommand
+/lootall
+```
 
 ## Description
 

--- a/reference/commands/macro.md
+++ b/reference/commands/macro.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/macro** _filename_ **[** _param0_ **[** _param1_ **[**...**]]]**
+```eqcommand
+/macro <filename> [ <param0> [ <param1> [...]]]
+```
 
 ## Description
 

--- a/reference/commands/makemevisible.md
+++ b/reference/commands/makemevisible.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/makemevisible**
+```eqcommand
+/makemevisible
+```
 
 ## Description
 

--- a/reference/commands/memspell.md
+++ b/reference/commands/memspell.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/memspell** _gem_ "_spellname_"
+```eqcommand
+/memspell <gem> "<spellname>"
+```
 
 ## Description
 

--- a/reference/commands/mercswitch.md
+++ b/reference/commands/mercswitch.md
@@ -5,7 +5,9 @@ tags:
 # /mercswitch
 
 ## Syntax
-**/mercswitch** _type_
+```eqcommand
+/mercswitch <type>
+```
 
 ## Description
 Extends the default EverQuest command to add the `<type>` option. Valid types are: Healer, Damage Caster, Melee Damage, Tank. A list of your mercenaries, their types and indices can be found in the "Switch" tab of your `/mercwindows`. 

--- a/reference/commands/mouseto.md
+++ b/reference/commands/mouseto.md
@@ -5,7 +5,9 @@ tags:
 # /mouseto
 
 ## Syntax
-**/mouseto** _X or X offset_ **[** _Y or Y offset_ **]**
+```eqcommand
+/mouseto <X or X offset> [ <Y or Y offset> ]
+```
 
 ## Description
 

--- a/reference/commands/mqanon.md
+++ b/reference/commands/mqanon.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/mqanon** [*command*] [*parameters*] [*strategy*]
+```eqcommand
+/mqanon [*command*] [*parameters*] [*strategy*]
+```
 
 ## Description
 

--- a/reference/commands/mqconsole.md
+++ b/reference/commands/mqconsole.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/mqconsole [clear | toggle | show | hide]**
+```eqcommand
+/mqconsole [clear | toggle | show | hide]
+```
 
 ## Description
 

--- a/reference/commands/mqcopylayout.md
+++ b/reference/commands/mqcopylayout.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/mqcopylayout** _charname_ _server_ **[res:**_W_**x**_H_**]** **[nohot]** **[noload]** **[nosoc]** **[none]**
+```eqcommand
+/mqcopylayout <charname> <server> [res:<W>x<H>] [nohot] [noload] [nosoc] [none]
+```
 
 ## Description
 

--- a/reference/commands/mqlistmodules.md
+++ b/reference/commands/mqlistmodules.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/mqlistmodules [**_name_**]**
+```eqcommand
+/mqlistmodules [<name>]
+```
 
 ## Description
 List loaded modules in the MQ directory to help with debugging stuck and/or broken dependencies/plugins. `<name>` is a filter. 

--- a/reference/commands/mqlistprocesses.md
+++ b/reference/commands/mqlistprocesses.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/mqlistprocesses [**_name_**]**
+```eqcommand
+/mqlistprocesses [<name>]
+```
 
 ## Description
 List relevant processes to help debug stuck and/or broken dependencies/plugins. `<name>` is a filter. 

--- a/reference/commands/mqlog.md
+++ b/reference/commands/mqlog.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/mqlog clear |** _text_
+```eqcommand
+/mqlog clear | <text>
+```
 
 ## Description
 

--- a/reference/commands/mqoverlay.md
+++ b/reference/commands/mqoverlay.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/mqoverlay [reload | resume | stop | start | cursor [on|off] debug [mouse|graphics|fonts|cursor]]**
+```eqcommand
+/mqoverlay [reload | resume | stop | start | cursor [on|off] debug [mouse|graphics|fonts|cursor]]
+```
 
 ## Description
 

--- a/reference/commands/mqpause.md
+++ b/reference/commands/mqpause.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/mqpause [on|off] | chat [on|off]**
+```eqcommand
+/mqpause [on|off] | chat [on|off]
+```
 
 ## Description
 

--- a/reference/commands/mqsettings.md
+++ b/reference/commands/mqsettings.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/mqsettings [Section to Open]**
+```eqcommand
+/mqsettings [Section to Open]
+```
 
 ## Description
 

--- a/reference/commands/mqtarget.md
+++ b/reference/commands/mqtarget.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/mqtarget** _**option**_
+```eqcommand
+/mqtarget <option>
+```
 
 ## Description
 

--- a/reference/commands/msgbox.md
+++ b/reference/commands/msgbox.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/msgbox** _message_
+```eqcommand
+/msgbox <message>
+```
 
 ## Description
 

--- a/reference/commands/multiline.md
+++ b/reference/commands/multiline.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/multiline** _**delimiter command**_ **\[** _**delimiter command**_ **\[...] ]**
+```eqcommand
+/multiline <delimiter> <command> [ <delimiter> <command> [...] ]
+```
 
 ## Description
 

--- a/reference/commands/netstatusxpos.md
+++ b/reference/commands/netstatusxpos.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/netstatusxpos** _**XXX**_
+```eqcommand
+/netstatusxpos <XXX>
+```
 
 ## Description
 

--- a/reference/commands/netstatusypos.md
+++ b/reference/commands/netstatusypos.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/netstatusypos** _**XXX**_
+```eqcommand
+/netstatusypos <XXX>
+```
 
 ## Description
 

--- a/reference/commands/next.md
+++ b/reference/commands/next.md
@@ -5,13 +5,14 @@ tags:
 # /next
 
 ## Syntax
-
 ```eqcommand
-/for <varname initial-value> to\|downto final-value [step <interval>]
+/for <varname> <initial-value> to|downto <final-value> [step <interval>]
+/next <varname>
 ```
-
-**/next** _**varname**_
 
 ## Description
 
-This runs all commands between the /for line and the /next line, after which it increments/decrements the _varname_ number (\#1\) by _step_ number (\#3) \(default is 1) before running through the commands again. It will keep doing this until the _varname_ number equals \#2. You can end a /for loop immediately with /break or try the next iteration with /continue.
+This runs all commands between the /for line and the /next line, after which it increments/decrements the _varname_ number (#1) by _step_ number (#3) \(default is 1) before running through the commands again. It will keep doing this until the _varname_ number equals #2. You can end a /for loop immediately with /break or try the next iteration with /continue.
+
+## See also
+* [/for](for.md)

--- a/reference/commands/next.md
+++ b/reference/commands/next.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/for** _**varname** initial-value_ **to\|downto** final-value **[step** _interval_**]**
+```eqcommand
+/for <varname initial-value> to\|downto final-value [step <interval>]
+```
 
 **/next** _**varname**_
 

--- a/reference/commands/no.md
+++ b/reference/commands/no.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/no**
+```eqcommand
+/no
+```
 
 ## Description
 

--- a/reference/commands/nomodkey.md
+++ b/reference/commands/nomodkey.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/nomodkey** _**command**_
+```eqcommand
+/nomodkey <command>
+```
 
 ## Description
 

--- a/reference/commands/noparse.md
+++ b/reference/commands/noparse.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/noparse** _**command**_
+```eqcommand
+/noparse <command>
+```
 
 ## Description
 

--- a/reference/commands/notify.md
+++ b/reference/commands/notify.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/notify** _windowname_ _control_ **[** _notification_ **[** _data_ **] ]**
+```eqcommand
+/notify <windowname> <control> [ <notification> [ <data> ] ]
+```
 
 ## Description
 

--- a/reference/commands/pet.md
+++ b/reference/commands/pet.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/pet** _action_ _spawnid_
+```eqcommand
+/pet <action> <spawnid>
+```
 
 ## Description
 

--- a/reference/commands/pickzone.md
+++ b/reference/commands/pickzone.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/pickzone** _#_
+```eqcommand
+/pickzone <#>
+```
 
 ## Description
 

--- a/reference/commands/plugin.md
+++ b/reference/commands/plugin.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/plugin** _name_ **[ load | unload | toggle ] [noauto] | [list]**
+```eqcommand
+/plugin <name> [ load | unload | toggle ] [noauto] | [list]
+```
 
 ## Description
 

--- a/reference/commands/popcustom.md
+++ b/reference/commands/popcustom.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/popcustom [**_color_**] [**_time_in_seconds_to_display_message_**]** _message_
+```eqcommand
+/popcustom [<#color>] [<#seconds>] <message>
+```
 
 ## Description
 

--- a/reference/commands/popup.md
+++ b/reference/commands/popup.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/popup** _**text**_
+```eqcommand
+/popup <text>
+```
 
 ## Description
 

--- a/reference/commands/popupecho.md
+++ b/reference/commands/popupecho.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/popupecho [**_color_**] [**_time_in_seconds_to_display_message_**]** _message_
+```eqcommand
+/popupecho [<#color>] [<#seconds>] <message>
+```
 
 ## Description
 

--- a/reference/commands/profile.md
+++ b/reference/commands/profile.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/profile** _profile_
+```eqcommand
+/profile <profile>
+```
 
 ## Description
 

--- a/reference/commands/quit.md
+++ b/reference/commands/quit.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/quit**
+```eqcommand
+/quit
+```
 
 ## Description
 

--- a/reference/commands/ranged.md
+++ b/reference/commands/ranged.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/ranged [** _**spawnID**_ **]**
+```eqcommand
+/ranged [ <spawnID> ]
+```
 
 ## Description
 

--- a/reference/commands/reloadui.md
+++ b/reference/commands/reloadui.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/reloadui**
+```eqcommand
+/reloadui
+```
 
 ## Description
 

--- a/reference/commands/removeaug.md
+++ b/reference/commands/removeaug.md
@@ -7,7 +7,9 @@ tags:
 
 ## Syntax
 
-**/removeaug** _augment_ _item_
+```eqcommand
+/removeaug <augment> <item>
+```
 
 ## Description
 

--- a/reference/commands/removeaura.md
+++ b/reference/commands/removeaura.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/removeaura Name Of Aura**
+```eqcommand
+/removeaura <Name Of Aura>
+```
 
 ## Description
 

--- a/reference/commands/removebuff.md
+++ b/reference/commands/removebuff.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/removebuff [-pet\|-both] Name Of Buff**
+```eqcommand
+/removebuff [-pet|-both] <Name Of Buff>
+```
 
 ## Description
 

--- a/reference/commands/removelev.md
+++ b/reference/commands/removelev.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/removelev**
+```eqcommand
+/removelev
+```
 
 ## Description
 

--- a/reference/commands/removepetbuff.md
+++ b/reference/commands/removepetbuff.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/removepetbuff Buff Name**
+```eqcommand
+/removepetbuff <Buff Name>
+```
 
 ## Description
 

--- a/reference/commands/return.md
+++ b/reference/commands/return.md
@@ -7,7 +7,7 @@ tags:
 ## Syntax
 
 ```eqcommand
-/return [value\|${varname}]
+/return [value|${varname}]
 ```
 
 ## Description

--- a/reference/commands/return.md
+++ b/reference/commands/return.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/return [value\|${varname}]**
+```eqcommand
+/return [value\|${varname}]
+```
 
 ## Description
 

--- a/reference/commands/screenmode.md
+++ b/reference/commands/screenmode.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/screenmode** _#_
+```eqcommand
+/screenmode <#>
+```
 
 ## Description
 

--- a/reference/commands/selectitem.md
+++ b/reference/commands/selectitem.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/selecitem** "itemname"
+```eqcommand
+/selecitem "itemname"
+```
 
 ## Description
 

--- a/reference/commands/sellitem.md
+++ b/reference/commands/sellitem.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/sellitem [\#]**
+```eqcommand
+/sellitem [<#quantity>]
+```
 
 ## Description
 

--- a/reference/commands/setautorun.md
+++ b/reference/commands/setautorun.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/setautorun**
+```eqcommand
+/setautorun
+```
 
 ## Description
 

--- a/reference/commands/seterror.md
+++ b/reference/commands/seterror.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/seterror [** _**error**_ **]**
+```eqcommand
+/seterror [ <error> ]
+```
 
 ## Description
 

--- a/reference/commands/setprio.md
+++ b/reference/commands/setprio.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/setprio** \#
+```eqcommand
+/setprio <#priority>
+```
 
 ## Description
 

--- a/reference/commands/setwintitle.md
+++ b/reference/commands/setwintitle.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/setwintitle** _Window Name_
+```eqcommand
+/setwintitle <Window Name>
+```
 
 ## Description
 

--- a/reference/commands/shiftkey.md
+++ b/reference/commands/shiftkey.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/shiftkey** _**command**_
+```eqcommand
+/shiftkey <command>
+```
 
 ## Description
 

--- a/reference/commands/skills.md
+++ b/reference/commands/skills.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/skills [** _**skillname**_ **]**
+```eqcommand
+/skills [ <skillname> ]
+```
 
 ## Description
 

--- a/reference/commands/spellslotinfo.md
+++ b/reference/commands/spellslotinfo.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/spellslotinfo** **[\#\|"spell name"]**
+```eqcommand
+/spellslotinfo [#|"<spell name>"]
+```
 
 ## Description
 

--- a/reference/commands/spew.md
+++ b/reference/commands/spew.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/spew [on\|off]**
+```eqcommand
+/spew [on|off]
+```
 
 ## Description
 

--- a/reference/commands/squelch.md
+++ b/reference/commands/squelch.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/squelch** _**command**_
+```eqcommand
+/squelch <command>
+```
 
 ## Description
 

--- a/reference/commands/target.md
+++ b/reference/commands/target.md
@@ -9,7 +9,9 @@ tags:
 
 ## Syntax
 
-**/target** _**option**_
+```eqcommand
+/target <option>
+```
 
 ## Description
 

--- a/reference/commands/taskquit.md
+++ b/reference/commands/taskquit.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/taskquit** [_name_]
+```eqcommand
+/taskquit [<name>]
+```
 
 ## Description
 

--- a/reference/commands/timed.md
+++ b/reference/commands/timed.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/timed \#** _**command**_
+```eqcommand
+/timed <#deciseconds> <command>
+```
 
 ## Description
 

--- a/reference/commands/timestamp.md
+++ b/reference/commands/timestamp.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/timestamp [on|off]**
+```eqcommand
+/timestamp [on|off]
+```
 
 ## Description
 Toggles timestamps on all chat messages. It can be set in MacroQuest.ini via `TimeStampChat=1` (1=ON, 0=OFF) in the [MacroQuest] section.

--- a/reference/commands/tloc.md
+++ b/reference/commands/tloc.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/tloc**
+```eqcommand
+/tloc
+```
 
 ## Description
 

--- a/reference/commands/unload.md
+++ b/reference/commands/unload.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/unload**
+```eqcommand
+/unload
+```
 
 ## Description
 

--- a/reference/commands/useitem.md
+++ b/reference/commands/useitem.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/useitem** _item name_
+```eqcommand
+/useitem <item name>
+```
 
 ## Description
 

--- a/reference/commands/usercamera.md
+++ b/reference/commands/usercamera.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/usercamera [** _0-7_ **|on|off|save [** _charname_ **]|load [** _charname_ **]]**
+```eqcommand
+/usercamera [ <0-7> |on|off|save [ <charname> ]|load [ <charname> ]]
+```
 
 ## Description
 

--- a/reference/commands/varcalc.md
+++ b/reference/commands/varcalc.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/varcalc varname** _**formula**_
+```eqcommand
+/varcalc varname <formula>
+```
 
 ## Description
 

--- a/reference/commands/vardata.md
+++ b/reference/commands/vardata.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/vardata varname** _**newMQ2Datavalue**_
+```eqcommand
+/vardata varname <newMQ2Datavalue>
+```
 
 ## Description
 

--- a/reference/commands/varset.md
+++ b/reference/commands/varset.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/varset varname [** _**newvalue**_ **]**
+```eqcommand
+/varset varname [ <newvalue> ]
+```
 
 ## Description
 

--- a/reference/commands/where.md
+++ b/reference/commands/where.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/where [ pc \| npc \] \[** _**spawnname**_ **]**
+```eqcommand
+/where [ pc | npc ] [ <spawnname> ]
+```
 
 ## Description
 

--- a/reference/commands/while.md
+++ b/reference/commands/while.md
@@ -8,11 +8,9 @@ tags:
 
 ```eqcommand
 /while (condition) {
-```
-
 `...`
-
-**}**
+}
+```
 
 ## Description
 

--- a/reference/commands/while.md
+++ b/reference/commands/while.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/while (condition) {**
+```eqcommand
+/while (condition) {
+```
 
 `...`
 

--- a/reference/commands/who.md
+++ b/reference/commands/who.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/who** _**options**_
+```eqcommand
+/who <options>
+```
 
 ## Description
 

--- a/reference/commands/whofilter.md
+++ b/reference/commands/whofilter.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/whofilter lastname|class|race|body|level|gm|guild|ld|sneak|lfg|npctag|spawnid|trader|afk|anon|distance|light|holding|concolor|invisible [on|off]**
+```eqcommand
+/whofilter lastname|class|race|body|level|gm|guild|ld|sneak|lfg|npctag|spawnid|trader|afk|anon|distance|light|holding|concolor|invisible [on|off]
+```
 
 ## Description
 

--- a/reference/commands/whotarget.md
+++ b/reference/commands/whotarget.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/whotarget**
+```eqcommand
+/whotarget
+```
 
 ## Description
 

--- a/reference/commands/windows.md
+++ b/reference/commands/windows.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/windows [** _windowname_ **| open ]**
+```eqcommand
+/windows [ <windowname> | open ]
+```
 
 ## Description
 

--- a/reference/commands/windowstate.md
+++ b/reference/commands/windowstate.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/windowstate** _window_ **[open|close]**
+```eqcommand
+/windowstate <window> [open|close]
+```
 
 ## Description
 

--- a/reference/commands/yes.md
+++ b/reference/commands/yes.md
@@ -6,7 +6,9 @@ tags:
 
 ## Syntax
 
-**/yes**
+```eqcommand
+/yes
+```
 
 ## Description
 

--- a/stylesheets/extra.css
+++ b/stylesheets/extra.css
@@ -97,3 +97,32 @@ details {
         transform: none;
     }
 }
+
+/* Syntax highlighting for eq_lexers */
+.language-eqcommand .nt { 
+    font-weight: bold; 
+}  /* Slash commands */
+
+.language-eqcommand .nl { 
+    color: var(--md-code-hl-constant-color);
+}  /* optional keywords */
+
+.language-eqcommand .no { 
+    font-weight: bold; 
+    color: var(--md-code-hl-keyword-color)
+}  /* required keywords */
+
+.language-eqcommand .p { 
+    font-weight: normal; 
+}  /* Punctuation ({|[]<>...}) */
+
+.language-eqcommand .nv { 
+    font-style: italic; 
+    font-weight: normal; 
+}  /* optional variable placeholders */
+
+.language-eqcommand .nv-Required { 
+    font-style: italic; 
+    font-weight: bold; 
+    color: var(--md-code-hl-name-color);
+}  /* required variable placeholders */


### PR DESCRIPTION
The eqcommand lexer makes the doc more legible when formatted,

before,
![image](https://github.com/user-attachments/assets/c25fd998-0d19-4b74-99b3-5a81b7d8baf7)

after,
![image](https://github.com/user-attachments/assets/ece8d502-e0d5-4b41-88d8-bbe5ea307b66)

It's also more legible in raw markdown,

before,
`**/caption list | update** _#_ **| MQCaptions [on|off] | reload | _type_** _value_ `
after,
`/caption list | update <#> | MQCaptions [on|off] | reload | <type> <value> `