### PR TITLE
remove 'Commands from Plugins' section

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -455,12 +455,6 @@ nav:
     - EQ Commands:
       - /lootnodrop: reference/commands/eq/lootnodrop.md
 
-    - Commands From Plugins:
-      - HUD:
-        - /loadhud: plugins/core-plugins/hud/loadhud.md
-      - ChatWnd:
-        - /mqfont: plugins/core-plugins/chatwnd/mqfont.md
-
   - Top Level Objects:
     - reference/top-level-objects/README.md
     - Achievement: reference/top-level-objects/tlo-achievement.md


### PR DESCRIPTION
This removes the "Commands From Plugins" section in nav.  With the previous PR there is now a section on the index page for plugin commands:

https://docs.macroquest.org/reference/commands/#from-core-plugins

