### PR TITLE
Add missing info for /mqoverlay

### DIFF
--- a/reference/commands/mqoverlay.md
+++ b/reference/commands/mqoverlay.md
@@ -7,7 +7,7 @@ tags:
 ## Syntax
 <!--cmd-syntax-start-->
 ```eqcommand
-/mqoverlay [reload | resume | stop | start | cursor [on|off] debug [mouse|graphics|fonts|cursor]]
+/mqoverlay [reload | resume | stop | start | cursor [on|off] | perchar [on|off] | copy {[server] <character> | default} | debug [mouse|graphics|fonts|cursor]]
 ```
 <!--cmd-syntax-end-->
 
@@ -17,7 +17,13 @@ Simple controls for the imgui overlay in MacroQuest. If imgui crashes, it can be
 <!--cmd-desc-end-->
 ## Parameters
 
-- **reload** - Reloads the overlay
-- **resume** - If imgui crashes, it can be resumed with this option.
-- **start|stop** - Starts or stops the overlay
+- **reload** - Reload the overlay by shutting it down and starting it back up again.
+- **resume** - Resumes the overlay in the event that an error has occurred.
+- **stop** - Turns off the overlay. This state does not persist between MQ sessions.
+- **start** - Turns on the overlay.
+- **cursor [on|off]** - Turn cursor attachment emulation on/off (no param will toggle).
+- **perchar [on|off]** - Turn per character overlay INI file on/off (no param will toggle).
+- **copy** - Copy an overlay INI configuration to the currently logged in character.
+    - `copy [server] character` - From the specified server+character (defaults to current server).
+    - `copy default` - From the default overlay INI file.
 - **debug** - overlay debug info


### PR DESCRIPTION
* Updated other text to match in-game print.
* Resolves #76

Broke out stop/start and matched docs with in-game print. I followed existing doc formatting as best as possible, but it appears to be a hodge-podge. There's a little creative license on how I broke up the two different paths for the copy param.

in-game print for reference
```
Usage: /mqoverlay <options>
Overlay Control Options:
  reload - Reload the overlay by shutting it down and starting it back up again.
  resume - Resumes the overlay in the event that an error has occurred.
  stop - Turns off the overlay. This state does not persist between MQ sessions.
  start - Turns on the overlay.
  cursor [on|off] - Turn cursor attachment emulation on/off (no param will toggle).
  perchar [on|off] - Turn per character overlay INI file on/off (no param will toggle).
  copy [server] <character> - Copy the overlay INI configuration of the specified server+character to the currently logged in character (defaults to current server).
    Use /mqoverlay copy default to copy from the default overlay ini file
```
